### PR TITLE
Add Unit Tests for Distance Enum (Euclidean, Cosine, Manhattan, Chebyshev)

### DIFF
--- a/tests/test_distance_enum.py
+++ b/tests/test_distance_enum.py
@@ -1,0 +1,27 @@
+import numpy as np
+import pytest
+from rust_annie import Distance, AnnIndex
+
+# Sample vectors
+v0 = np.array([0.0, 0.0], dtype=np.float32)
+v1 = np.array([1.0, 1.0], dtype=np.float32)
+
+@pytest.mark.parametrize(
+    "metric, expected_fn",
+    [
+        (Distance.EUCLIDEAN, lambda a, b: np.linalg.norm(a - b)),
+        (Distance.COSINE, lambda a, b: 1 - (np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-8))),
+        (Distance.MANHATTAN, lambda a, b: np.sum(np.abs(a - b))),
+        (Distance.CHEBYSHEV, lambda a, b: np.max(np.abs(a - b))),
+    ]
+)
+def test_distance_behavior(metric, expected_fn):
+    
+    index = AnnIndex(dim=2, metric=metric)
+    index.add(np.array([v0]), np.array([0], dtype=np.int64))
+
+  
+    labels, dists = index.search(v1, k=1)
+    
+    assert labels[0] == 0
+    np.testing.assert_allclose(dists[0], expected_fn(v0, v1), rtol=1e-5)


### PR DESCRIPTION
### **What does this PR do?**

* Adds tests for Distance Enum (Euclidean, Cosine, Manhattan, Chebyshev) under the issue #7 

---

### **Summary of the changes:**

This PR adds unit tests to validate the behavior of the `Distance` enum used in the `AnnIndex` class.
The tests cover:

* **Euclidean distance**
* **Cosine similarity**
* **Manhattan (L1) distance**
* **Chebyshev (L∞) distance**

Using `pytest.mark.parametrize`, I systematically verify that each distance metric returns the correct values when comparing sample vectors.

These tests will ensure that the distance computation logic remains accurate and consistent during future changes.

---

### **Checklist:**

* My code follows the style guidelines of this project
* I have performed a self-review of my code
* I have commented my code, especially in hard-to-understand areas
* I have added necessary tests
* All new and existing tests pass
