### PR TITLE
Standardized RustAnnError::py_err(...) function.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ impl RustAnnError {
     /// Create a generic Python exception (`Exception`) with the given message.
     pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
         let msg = format!("RustAnnError [{}]: {}", type_name.into(), detail.into());
-        PyException::new_err(msg.into())
+        PyException::new_err(msg.into());
     }
 
     /// Create a RustAnnError wrapping an I/O error message.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,8 @@ pub struct RustAnnError(pub String);
 
 impl RustAnnError {
     /// Create a generic Python exception (`Exception`) with the given message.
-    pub fn py_err(msg: impl Into<String>) -> PyErr {
+    pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
+        let msg = format!("RustAnnError [{}]: {}", type_name.into(), detail.into());
         PyException::new_err(msg.into())
     }
 


### PR DESCRIPTION
## Standardizing py_err() function

**PR Type**
- Feature enhancement

**Related Issue(s):**
Closes #11 

**Summary of the changes:**
1. Made changes in the function RustAnnError:: py_err() in the error.rs file to accept **error type** and **error message** as arguments.
2. Added error type in **index.rs** file wherever the py_err() function is used.

I have added screenshots of the code changes I made in the **error.rs** file and the **index.rs** file. @maxprogrammer007  Please review these changes. If there is anything that needs to be changed or added, do let me know. I will do it right away.


## error.rs file changes
![Screenshot from 2025-06-14 17-27-02](https://github.com/user-attachments/assets/49b7efe1-8b18-4cd0-b79f-e6657400f81d)

## index.rs file changes
![Screenshot from 2025-06-14 17-27-22](https://github.com/user-attachments/assets/d0506953-ad0c-48ae-9580-388e14a2975c)

![Screenshot from 2025-06-14 17-27-33](https://github.com/user-attachments/assets/2d84ef26-d0f4-4759-8189-4a7d1af4465b)

![Screenshot from 2025-06-14 17-27-54](https://github.com/user-attachments/assets/cc6726e9-94e1-494a-b5a1-922aa6cce0ad)

![Screenshot from 2025-06-14 17-28-04](https://github.com/user-attachments/assets/5bfc4e60-4ed4-46dc-8daa-6aad87a1de90)

![Screenshot from 2025-06-14 17-28-16](https://github.com/user-attachments/assets/629c69de-b2bf-42a5-bed8-c924cacb6cf7)

![Screenshot from 2025-06-14 17-28-26](https://github.com/user-attachments/assets/a03c4e33-5bc5-40a8-abb4-cab5f8087cc1)



---
## EntelligenceAI PR Summary 
 Refactored error handling for improved Python exception messages.
- Updated `RustAnnError::py_err` in `src/errors.rs` to accept error type and detail
- Modified all usages in `src/index.rs` to match new signature and provide structured error information 

