### PR TITLE
Standardized RustAnnError::py_err(...) function.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ impl RustAnnError {
     /// Create a generic Python exception (`Exception`) with the given message.
     pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
         let msg = format!("RustAnnError [{}]: {}", type_name.into(), detail.into());
-        PyException::new_err(msg.into())
+        PyException::new_err(msg.into());
     }
 
     /// Create a RustAnnError wrapping an I/O error message.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ impl RustAnnError {
     /// Create a generic Python exception (`Exception`) with the given message.
     pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
         let msg = format!("RustAnnError [{}]: {}", type_name.into(), detail.into());
-        PyException::new_err(msg.into());
+        PyException::new_err(msg.into())
     }
 
     /// Create a RustAnnError wrapping an I/O error message.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,8 +10,10 @@ pub struct RustAnnError(pub String);
 impl RustAnnError {
     /// Create a generic Python exception (`Exception`) with the given message.
     pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
-        let msg = format!("RustAnnError [{}]: {}", type_name.into(), detail.into());
-        PyException::new_err(msg.into())
+        let safe_type = type_name.into().replace(['\n', '\r'], " ");
+        let safe_detail = detail.into().replace(['\n', '\r'], " ");
+        let msg = format!("RustAnnError [{}]: {}", safe_type, safe_detail);
+        PyException::new_err(msg)
     }
 
     /// Create a RustAnnError wrapping an I/O error message.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,7 +8,7 @@ use pyo3::PyErr;
 pub struct RustAnnError(pub String);
 
 impl RustAnnError {
-    /// Create a generic Python exception (`Exception`) with the given message.
+    /// Create a generic Python exception (`Exception`) with the error type and error message.
     pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
         let safe_type = type_name.into().replace(['\n', '\r'], " ");
         let safe_detail = detail.into().replace(['\n', '\r'], " ");

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,8 @@ pub struct RustAnnError(pub String);
 
 impl RustAnnError {
     /// Create a generic Python exception (`Exception`) with the given message.
-    pub fn py_err(msg: impl Into<String>) -> PyErr {
+    pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
+        let msg = format!("RustAnnError [{}]: {}", type_name.into(), detail.into());
         PyException::new_err(msg.into())
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,7 +10,7 @@ pub struct RustAnnError(pub String);
 impl RustAnnError {
     /// Create a generic Python exception (`Exception`) with the error type and error message.
     pub fn py_err(type_name: impl Into<String>, detail: impl Into<String>) -> PyErr {
-        let safe_type = type_name.into().replace(['\n', '\r'], " ");
+        let safe_type = type_name.into().replace(['\n', '\r', '[', ']'], " ");
         let safe_detail = detail.into().replace(['\n', '\r'], " ");
         let msg = format!("RustAnnError [{}]: {}", safe_type, safe_detail);
         PyException::new_err(msg)


### PR DESCRIPTION
## Standardizing py_err() function

**PR Type**
- Feature enhancement

**Related Issue(s):**
Closes #11 

**Summary of the changes:**
1. Made changes in the function RustAnnError:: py_err() in the error.rs file to accept **error type** and **error message** as arguments.
2. Sanitized all the error types and error messages.
3. Added error type in **index.rs** file wherever the py_err() function is used.

I have added screenshots of the code changes I made in the **error.rs** file and the **index.rs** file. @maxprogrammer007  Please review these changes. If there is anything that needs to be changed or added, do let me know. I will do it right away.

## error.rs file changes
![Screenshot from 2025-06-14 17-59-25](https://github.com/user-attachments/assets/3439de20-845d-4aef-a68b-a958deaf2973)

## index.rs file changes

### Line No:32
![Screenshot from 2025-06-14 18-17-34](https://github.com/user-attachments/assets/b54f5593-87c7-47e6-b1ea-05cd1d6a8808)


### Line No:46, 49
![Screenshot from 2025-06-14 18-18-15](https://github.com/user-attachments/assets/9ad6c6c2-41e8-4c6b-a1a2-90c960ecc59a)


### Line No:69, 74
![Screenshot from 2025-06-14 18-19-01](https://github.com/user-attachments/assets/5a9b1421-2a6f-4dd3-9119-2357e5c4f942)


### Line No:150, 152
![Screenshot from 2025-06-14 18-19-42](https://github.com/user-attachments/assets/47701e69-4fee-48ac-9ab9-e13cdefa14d8)


### Line No:178
![Screenshot from 2025-06-14 18-20-46](https://github.com/user-attachments/assets/c8aad6f6-54f9-4c73-9ddd-e304b6468daf)








---
## EntelligenceAI PR Summary 
 Refactored error reporting for improved structure and clarity:
- Updated RustAnnError::py_err in src/errors.rs to accept and sanitize error type and detail
- Refactored src/index.rs to use the new error reporting format throughout AnnIndex 

