### PR TITLE
add metric test and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "rust_annie"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "bincode",
  "ndarray",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.3"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # PyO3 for Python bindings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 mod index;
 mod storage;
-mod metrics;
+pub mod metrics;
 mod errors;
 mod concurrency;
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -31,3 +31,23 @@ impl Distance {
         }
     }
 }
+
+pub fn euclidean(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y).powi(2)).sum::<f32>().sqrt()
+}
+pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    let dot_product = a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>();
+    let norm_a = a.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
+    let norm_b = b.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        return 1.0; // Maximum distance
+    }
+    1.0 - dot_product / (norm_a * norm_b)
+}
+pub fn manhattan(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y).abs()).sum()
+}
+
+pub fn chebyshev(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| (x - y).abs()).fold(0.0, f32::max)
+}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -33,9 +33,11 @@ impl Distance {
 }
 
 pub fn euclidean(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "Input slices must have the same length");
     a.iter().zip(b).map(|(x, y)| (x - y).powi(2)).sum::<f32>().sqrt()
 }
 pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "Input slices must have the same length");
     let dot_product = a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>();
     let norm_a = a.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
     let norm_b = b.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
@@ -45,9 +47,11 @@ pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
     1.0 - dot_product / (norm_a * norm_b)
 }
 pub fn manhattan(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "Input slices must have the same length");
     a.iter().zip(b).map(|(x, y)| (x - y).abs()).sum()
 }
 
 pub fn chebyshev(a: &[f32], b: &[f32]) -> f32 {
+    assert_eq!(a.len(), b.len(), "Input slices must have the same length");
     a.iter().zip(b).map(|(x, y)| (x - y).abs()).fold(0.0, f32::max)
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -37,20 +37,18 @@ pub fn euclidean(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b).map(|(x, y)| (x - y).powi(2)).sum::<f32>().sqrt()
 }
 pub fn cosine(a: &[f32], b: &[f32]) -> f32 {
-    assert_eq!(a.len(), b.len(), "Input slices must have the same length");
     let dot_product = a.iter().zip(b).map(|(x, y)| x * y).sum::<f32>();
-    let norm_a = a.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
-    let norm_b = b.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
+    let norm_a = a.iter().map(|x| x.powi(2)).sum::<f32>();
+    let norm_b = b.iter().map(|x| x.powi(2)).sum::<f32>();
     if norm_a == 0.0 || norm_b == 0.0 {
         return 1.0; // Maximum distance
     }
-    1.0 - dot_product / (norm_a * norm_b)
+    1.0 - dot_product / (norm_a * norm_b).sqrt()
 }
 pub fn manhattan(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len(), "Input slices must have the same length");
     a.iter().zip(b).map(|(x, y)| (x - y).abs()).sum()
 }
-
 pub fn chebyshev(a: &[f32], b: &[f32]) -> f32 {
     assert_eq!(a.len(), b.len(), "Input slices must have the same length");
     a.iter().zip(b).map(|(x, y)| (x - y).abs()).fold(0.0, f32::max)

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -7,10 +7,7 @@ use std::{
 };
 
 use bincode;
-use serde::{Serialize, de::DeserializeOwned};
-
-use pyo3::exceptions::PyIOError;
-
+use pyo3::prelude::*;
 use crate::errors::RustAnnError;
 use crate::index::AnnIndex;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -7,7 +7,10 @@ use std::{
 };
 
 use bincode;
-use pyo3::prelude::*;
+use serde::{Serialize, de::DeserializeOwned};
+
+use pyo3::exceptions::PyIOError;
+
 use crate::errors::RustAnnError;
 use crate::index::AnnIndex;
 

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -1,0 +1,37 @@
+use rust_annie::metrics::{euclidean, cosine, manhattan, chebyshev};
+
+fn approx_eq(a: f32, b: f32, tol: f32) -> bool {
+    (a - b).abs() < tol
+}
+
+#[test]
+fn test_euclidean() {
+    let a = &[1.0, 2.0, 3.0];
+    let b = &[4.0, 5.0, 6.0];
+    let dist = euclidean(a, b);
+    assert!(approx_eq(dist, 5.196152, 1e-5));
+}
+
+#[test]
+fn test_cosine() {
+    let a = &[1.0, 0.0];
+    let b = &[0.0, 1.0];
+    let dist = cosine(a, b);
+    assert!(approx_eq(dist, 1.0, 1e-5)); // cosine distance of orthogonal vectors is 1
+}
+
+#[test]
+fn test_manhattan() {
+    let a = &[1.0, 2.0, 3.0];
+    let b = &[4.0, 5.0, 6.0];
+    let dist = manhattan(a, b);
+    assert!(approx_eq(dist, 9.0, 1e-5));
+}
+
+#[test]
+fn test_chebyshev() {
+    let a = &[1.0, 2.0, 3.0];
+    let b = &[4.0, 5.0, 7.0];
+    let dist = chebyshev(a, b);
+    assert!(approx_eq(dist, 4.0, 1e-5));
+}


### PR DESCRIPTION
**What does this PR do?
- [x] Fixes a bug
- [x] Adds a new feature
- [x] Adds tests

** Summary of Changes
This PR implements **Manhattan** and **Chebyshev** distance metrics in the brute-force index.

- Added `Distance::Manhattan` and `Distance::Chebyshev` variants to `src/metrics.rs`
- Implemented corresponding distance functions (`manhattan` and `chebyshev`)
- Integrated both metrics into the `inner_search` logic
- Added unit tests in `tests/metrics.rs` to verify correctness

** Related Issue(s)
Closes #9

** Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary, especially in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass

---
## EntelligenceAI PR Summary 
 This PR enhances the library with new distance metric functions, public module access, improved build options, and expanded test coverage.
- Made 'metrics' module public (src/lib.rs)
- Added euclidean, cosine, manhattan, chebyshev functions (src/metrics.rs)
- Introduced unit tests for metrics (tests/metrics.rs)
- Updated crate-type to include 'rlib' (Cargo.toml)
- Bumped 'rust_annie' version (Cargo.lock)
- Streamlined imports in storage module (src/storage.rs) 

