### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,5 +1,8 @@
 name: Benchmark
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Programmers-Paradise/Annie/security/code-scanning/1](https://github.com/Programmers-Paradise/Annie/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves reading repository contents and committing/pushing updates, the permissions should include `contents: read` and `contents: write`. The `permissions` block can be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
