### PR TITLE
Fix panic in search_batch by using Result propagation and add test fo…

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -69,9 +69,10 @@ impl ThreadSafeAnnIndex {
     pub fn search_batch(&self, py: Python, data: PyReadonlyArray2<f32>, k: usize)
         -> PyResult<(PyObject, PyObject)>
     {
-        let guard = self.inner.read().map_err(|_| {
-                RustAnnError::py_err("Lock Error", "Failed to acquire read lock for search_batch")
-        })?;
+let guard = self.inner.read().map_err(|e| {
+        eprintln!("RwLock poisoned in search_batch: {:?}", e);
+        RustAnnError::py_err("Lock Error", "Failed to acquire read lock for search_batch")
+})?;
 
         guard.search_batch(py, data, k)
     }

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -69,9 +69,13 @@ impl ThreadSafeAnnIndex {
     pub fn search_batch(&self, py: Python, data: PyReadonlyArray2<f32>, k: usize)
         -> PyResult<(PyObject, PyObject)>
     {
-        let guard = self.inner.read().unwrap();
+        let guard = self.inner.read().map_err(|_| {
+                RustAnnError::py_err("Lock Error", "Failed to acquire read lock for search_batch")
+        })?;
+
         guard.search_batch(py, data, k)
     }
+
 
     /// Save the index to disk.
     ///

--- a/src/index.rs
+++ b/src/index.rs
@@ -165,7 +165,7 @@ impl AnnIndex {
                     let q: Vec<f32> = row.to_vec();
                     let q_sq = q.iter().map(|x| x * x).sum::<f32>();
                     self.inner_search(&q, q_sq, k).map_err(|e| {
-                        RustAnnError::py_err("SearchBatch Error", format!("Row {} failed: {}", i, e))
+                        RustAnnError::py_err("SearchBatch Error", format!("Row {} failed: {:#?}", i, e))
                     })
                 })
                 .collect()

--- a/tests/test_ann_index.py
+++ b/tests/test_ann_index.py
@@ -1,5 +1,6 @@
 from rust_annie import AnnIndex, Distance
 import numpy as np
+import pytest
 
 def test_len_and_dim():
     dim = 3
@@ -16,3 +17,14 @@ def test_len_and_dim():
 
     assert index.len() == 1
     assert index.dim() == dim
+
+def test_search_batch_invalid_dimension_should_fail():
+    index = AnnIndex(4, Distance.EUCLIDEAN)  # expects dim = 4
+    index.add(np.array([[1.0, 2.0, 3.0, 4.0]], dtype=np.float32), np.array([1], dtype=np.int64))
+
+    bad_query = np.array([[1.0, 2.0]], dtype=np.float32)  # dim = 2, should trigger failure
+
+    with pytest.raises(Exception) as e:
+        index.search_batch(bad_query, k=1)
+
+    assert "Expected dimension 4" in str(e.value)

--- a/tests/test_ann_index.py
+++ b/tests/test_ann_index.py
@@ -24,7 +24,7 @@ def test_search_batch_invalid_dimension_should_fail():
 
     bad_query = np.array([[1.0, 2.0]], dtype=np.float32)  # dim = 2, should trigger failure
 
-    with pytest.raises(Exception) as e:
+    with pytest.raises(ValueError) as e:  # Assuming ValueError is raised for invalid dimensions
         index.search_batch(bad_query, k=1)
 
     assert "Expected dimension 4" in str(e.value)


### PR DESCRIPTION
…r invalid dimension

# 🚀 Pull Request Template

**What does this PR do?**
- [x] Fixes a bug
- [ ] Adds a new feature
- [ ] Improves performance
- [x] Adds tests
- [ ] Updates documentation

**Summary of the changes:**
<!-- Write a short summary of the changes made -->
This PR improves error handling in the search_batch method of AnnIndex. Previously, calling search_batch() with incorrectly shaped queries (e.g., wrong dimension) would cause a panic due to .unwrap() inside a parallel iterator.
- Replaced .unwrap() with proper Result propagation using .map_err(...).
- Updated concurrency.rs to avoid .unwrap() on RwLock.
- Added a Python test (test_search_batch_invalid_dimension_should_fail) to verify that invalid dimensions raise a proper exception instead of panicking.

**Related Issue(s):**
Closes #62 

**Checklist:**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, especially in hard-to-understand areas
- [x]  I have added necessary tests
- [x] All new and existing tests pass

**Screenshots (if applicable):**
<!-- Drag and drop or paste images here -->


---
## EntelligenceAI PR Summary 
 - Improved error handling in `ThreadSafeAnnIndex::search_batch` and `AnnIndex` batch search logic to prevent panics and provide descriptive errors
- Added a test to ensure invalid query dimensions in batch search raise appropriate exceptions
- Changes affect `src/concurrency.rs`, `src/index.rs`, and `tests/test_ann_index.py` 

