### PR TITLE
Fix panic in search_batch by using Result propagation

### DIFF
--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -45,7 +45,7 @@ impl ThreadSafeAnnIndex {
         data: PyReadonlyArray2<f32>,
         ids: PyReadonlyArray1<i64>,
     ) -> PyResult<()> {
-        let mut guard = self.acquire_write()?;
+        let mut guard = self.self.inner.write().map_err(|e| RustAnnError::py_err("Lock Error", format!("Failed to acquire write lock: {}", e)))?;
         guard.add(py, data, ids)
     }
 

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -1,25 +1,14 @@
 //! Concurrency utilities: Python-visible thread-safe wrapper around `AnnIndex`.
-//!
-//! This module exposes a `ThreadSafeAnnIndex` that allows concurrent, thread-safe
-//! usage of the approximate nearest neighbor index from Python via PyO3.
-//!
-//! Internally, the index is protected by a `RwLock` so reads (searches) can happen
-//! concurrently, while writes (add/remove) are exclusive.
 
 use std::sync::{Arc, RwLock};
 use pyo3::prelude::*;
 use numpy::{PyReadonlyArray1, PyReadonlyArray2};
+
 use crate::index::AnnIndex;
 use crate::metrics::Distance;
 use crate::errors::RustAnnError;
 
 /// A thread-safe, Python-visible wrapper around [`AnnIndex`].
-///
-/// Internally, the index is guarded with an `RwLock`, allowing:
-/// - Concurrent reads (e.g., multiple searches in parallel)
-/// - Exclusive writes (e.g., add/remove operations)
-///
-/// This allows safe concurrent access from multiple Python threads or async contexts.
 #[pyclass]
 pub struct ThreadSafeAnnIndex {
     inner: Arc<RwLock<AnnIndex>>,
@@ -27,7 +16,7 @@ pub struct ThreadSafeAnnIndex {
 
 #[pymethods]
 impl ThreadSafeAnnIndex {
-    /// Create a new thread-safe ANN index with the given dimension and distance metric.
+    /// Create a new thread-safe ANN index.
     #[new]
     pub fn new(dim: usize, metric: Distance) -> PyResult<Self> {
         let idx = AnnIndex::new(dim, metric)?;
@@ -36,22 +25,20 @@ impl ThreadSafeAnnIndex {
         })
     }
 
-    /// Add new vectors and IDs to the index.
-    ///
-    /// This acquires a write lock and must be called with the Python GIL held.
+    /// Add vectors with IDs.
     pub fn add(
         &self,
         py: Python,
         data: PyReadonlyArray2<f32>,
         ids: PyReadonlyArray1<i64>,
     ) -> PyResult<()> {
-        let mut guard = self.self.inner.write().map_err(|e| RustAnnError::py_err("Lock Error", format!("Failed to acquire write lock: {}", e)))?;
+        let mut guard = self.inner.write().map_err(|e| {
+            RustAnnError::py_err("Lock Error", format!("Failed to acquire write lock: {}", e))
+        })?;
         guard.add(py, data, ids)
     }
 
-    /// Remove points from the index by ID.
-    ///
-    /// This acquires a write lock.
+    /// Remove by ID.
     pub fn remove(&self, _py: Python, ids: Vec<i64>) -> PyResult<()> {
         let mut guard = self.inner.write().map_err(|e| {
             RustAnnError::py_err("Lock Error", format!("Failed to acquire write lock: {}", e))
@@ -59,9 +46,7 @@ impl ThreadSafeAnnIndex {
         guard.remove(ids)
     }
 
-    /// Perform a k-NN search for a single query vector.
-    ///
-    /// This acquires a shared read lock and can run concurrently with other readers.
+    /// Single-vector k-NN search.
     pub fn search(
         &self,
         py: Python,
@@ -74,9 +59,7 @@ impl ThreadSafeAnnIndex {
         guard.search(py, query, k)
     }
 
-    /// Perform a batched k-NN search for multiple query vectors.
-    ///
-    /// This acquires a shared read lock and propagates any parallel search errors.
+    /// Batch k-NN search.
     pub fn search_batch(
         &self,
         py: Python,
@@ -89,9 +72,7 @@ impl ThreadSafeAnnIndex {
         guard.search_batch(py, data, k)
     }
 
-    /// Save the index to disk.
-    ///
-    /// This acquires a shared read lock.
+    /// Save to disk.
     pub fn save(&self, _py: Python, path: &str) -> PyResult<()> {
         let guard = self.inner.read().map_err(|e| {
             RustAnnError::py_err("Lock Error", format!("Failed to acquire read lock: {}", e))
@@ -99,7 +80,7 @@ impl ThreadSafeAnnIndex {
         guard.save(path)
     }
 
-    /// Load an index from disk and wrap it as a thread-safe object.
+    /// Load and wrap.
     #[staticmethod]
     pub fn load(_py: Python, path: &str) -> PyResult<Self> {
         let idx = AnnIndex::load(path)?;

--- a/src/concurrency.rs
+++ b/src/concurrency.rs
@@ -45,9 +45,7 @@ impl ThreadSafeAnnIndex {
         data: PyReadonlyArray2<f32>,
         ids: PyReadonlyArray1<i64>,
     ) -> PyResult<()> {
-        let mut guard = self.inner.write().map_err(|e| {
-            RustAnnError::py_err("Lock Error", format!("Failed to acquire write lock: {}", e))
-        })?;
+        let mut guard = self.acquire_write()?;
         guard.add(py, data, ids)
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -153,9 +153,17 @@ impl AnnIndex {
         data: PyReadonlyArray2<f32>,
         k: usize,
     ) -> PyResult<(PyObject, PyObject)> {
-         let arr = data.as_array();
-         let n = arr.nrows();
+        let arr = data.as_array();
+        let n = arr.nrows();
 
+      let arr = data.as_array();
+    let n = arr.nrows();
+    if arr.ncols() != self.dim {
+        return Err(RustAnnError::py_err(
+            "Dimension Error",
+            format!("Expected query shape (N, {}), got (N, {})", self.dim, arr.ncols())
+        ));
+    }
     let results: Result<Vec<_>, RustAnnError> = py.allow_threads(|| {
         (0..n)
             .into_par_iter()
@@ -166,6 +174,7 @@ impl AnnIndex {
                 self.inner_search(&q, q_sq, k)
             })
             .collect()
+    });
     });
 
     let (all_ids, all_dists): (Vec<_>, Vec<_>) = results?.into_iter().unzip();

--- a/src/index.rs
+++ b/src/index.rs
@@ -139,21 +139,22 @@ impl AnnIndex {
     }
 
     /// Batch-search k nearest neighbors for each row in an (N×dim) array.
-    ///
+    /// 
     /// Args:
     ///     query (ndarray): Query vector
     ///     k (int): Number of neighbors
+    ///     filter_fn (Callable[[int], bool]): Filter function
     ///
     /// Returns:
-    ///     Tuple[ndarray, ndarray]: (neighbor IDs, distances)
+    ///     Tuple[ndarray, ndarray]: Filtered (neighbor IDs, distances)
     pub fn search_batch(
         &self,
         py: Python,
         data: PyReadonlyArray2<f32>,
         k: usize,
     ) -> PyResult<(PyObject, PyObject)> {
-    let arr = data.as_array();
-    let n = arr.nrows();
+         let arr = data.as_array();
+         let n = arr.nrows();
 
     let results: Result<Vec<_>, RustAnnError> = py.allow_threads(|| {
         (0..n)
@@ -247,6 +248,7 @@ impl AnnIndex {
     Ok((ids, dists))
     }
 }
+
 impl AnnBackend for AnnIndex {
     fn new(dim: usize, metric: Distance) -> Self {
         AnnIndex {

--- a/src/index.rs
+++ b/src/index.rs
@@ -184,10 +184,7 @@ impl AnnIndex {
     let dists_arr: Array2<f32> = Array2::from_shape_vec((n, k), all_dists.concat())
         .map_err(|e| RustAnnError::py_err("Reshape Error", format!("Reshape dists failed: {}", e)))?;
 
-    Ok((
-        ids_arr.into_pyarray(py).to_object(py),
-        dists_arr.into_pyarray(py).to_object(py),
-    ))
+    Ok
     }
 
         // Flatten the results

--- a/src/index.rs
+++ b/src/index.rs
@@ -171,7 +171,7 @@ impl AnnIndex {
                 let q: Vec<f32> = row.to_vec();
                 let q_sq = q.iter().map(|x| x * x).sum::<f32>();
                 self.inner_search(&q, q_sq, k)
-                    .map_err(|e| RustAnnError::Custom(e.to_string())) // Explicit conversion
+                   .map_err(|e| RustAnnError::io_err(format!("Parallel search failed: {}", e)))
             })
             .collect()
         });

--- a/src/index.rs
+++ b/src/index.rs
@@ -175,7 +175,7 @@ impl AnnIndex {
             })
             .try_collect()
     });
-    });
+    
 
     let (all_ids, all_dists): (Vec<_>, Vec<_>) = results?.into_iter().unzip();
 
@@ -183,9 +183,6 @@ impl AnnIndex {
         .map_err(|e| RustAnnError::py_err("Reshape Error", format!("Reshape ids failed: {}", e)))?;
     let dists_arr: Array2<f32> = Array2::from_shape_vec((n, k), all_dists.concat())
         .map_err(|e| RustAnnError::py_err("Reshape Error", format!("Reshape dists failed: {}", e)))?;
-
-    Ok
-    }
 
         // Flatten the results
         let mut all_ids = Vec::with_capacity(n * k);

--- a/src/index.rs
+++ b/src/index.rs
@@ -173,7 +173,7 @@ impl AnnIndex {
                 let q_sq = q.iter().map(|x| x * x).sum::<f32>();
                 self.inner_search(&q, q_sq, k)
             })
-            .try_collect()
+            .collect()
     });
     
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -173,7 +173,7 @@ impl AnnIndex {
                 let q_sq = q.iter().map(|x| x * x).sum::<f32>();
                 self.inner_search(&q, q_sq, k)
             })
-            .collect()
+            .try_collect()
     });
     });
 

--- a/tests/test_threadsafeindex.rs
+++ b/tests/test_threadsafeindex.rs
@@ -1,0 +1,30 @@
+#[test]
+fn test_search_batch_poisoned_lock() {
+    use std::sync::{Arc, RwLock};
+    use rust_annie::concurrency::ThreadSafeAnnIndex;
+    use rust_annie::index::AnnIndex;
+    use rust_annie::metrics::Distance;
+    use pyo3::Python;
+    use numpy::{PyArray2, IntoPyArray};
+
+    // Poison the lock
+    let lock = Arc::new(RwLock::new(AnnIndex::new(2, Distance::L2).unwrap()));
+    {
+        let poisoned = Arc::clone(&lock);
+        let _ = std::thread::spawn(move || {
+            let _ = poisoned.write().unwrap();
+            panic!("Poisoning lock intentionally");
+        }).join();
+    }
+
+    let wrapped = ThreadSafeAnnIndex { inner: lock };
+
+    Python::with_gil(|py| {
+        let arr = vec![[1.0_f32, 2.0], [3.0, 4.0]];
+        let arr = PyArray2::from_owned_array(py, ndarray::Array2::from_shape_vec((2, 2), arr.concat()).unwrap());
+        let result = wrapped.search_batch(py, arr.readonly(), 1);
+        assert!(result.is_err());
+        let msg = format!("{:?}", result.unwrap_err());
+        assert!(msg.contains("Lock Error"));
+    });
+}


### PR DESCRIPTION
This PR improves error handling in the search_batch method of AnnIndex. Previously, calling search_batch() with incorrectly shaped queries (e.g., wrong dimension) would cause a panic due to .unwrap() inside a parallel iterator.

    Replaced .unwrap() with proper Result propagation using .map_err(...).
    Updated concurrency.rs to avoid .unwrap() on RwLock.
    Added a Python test (test_search_batch_invalid_dimension_should_fail) to verify that invalid dimensions raise a proper exception instead of panicking.

Related Issue(s):
Closes https://github.com/Programmers-Paradise/Annie/issues/62

Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, especially in hard-to-understand areas
- [ ] I have added necessary tests
- [ ] All new and existing tests pass

---
## EntelligenceAI PR Summary 
 This PR improves concurrency error handling and robustness in AnnIndex and its thread-safe wrapper.
- Replaces panic-based lock error handling with explicit error propagation in src/concurrency.rs
- Refactors search_batch in src/index.rs to propagate and handle errors robustly
- Adds a unit test in tests/test_threadsafeindex.rs for lock poisoning scenarios 

