### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,5 +1,8 @@
 name: Security Audit
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Programmers-Paradise/Annie/security/code-scanning/9](https://github.com/Programmers-Paradise/Annie/security/code-scanning/9)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN to the minimum required privileges. Since the workflow only checks out code, installs dependencies, runs audits, and uploads an artifact, it does not require write access to repository contents or other resources. The minimal required permission is `contents: read`, which allows the workflow to read repository contents. This block should be added at the workflow root (before `jobs:`) to apply to all jobs, unless a job requires additional permissions. No changes to steps or other workflow logic are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
