### PR TITLE
Revert "docs: Update serialization details for `hnsw_index` and `threadsafe_index`"

### DIFF
--- a/docs/api/hnsw_index.md
+++ b/docs/api/hnsw_index.md
@@ -108,8 +108,6 @@ The library now uses the `thiserror` crate for improved error handling. This cha
 
 The library uses the `serde` crate for serialization and deserialization, which has been updated to version `1.0.228`. This update ensures compatibility with the latest features and improvements in the `serde` ecosystem. Users should verify that their serialized data is compatible with this version.
 
-The `bincode` crate, used for serialization and deserialization, has been upgraded to version `3.0.0`. This upgrade may affect the compatibility of serialized data with previous versions. Users should ensure that their data is compatible with this new version.
-
 ## Integration with `python3-dll-a`
 
 The `python3-dll-a` package has been integrated into the library, potentially impacting the HNSW index API. This integration may enhance the library's functionality or performance, and users should review any related changes or improvements.

--- a/docs/api/threadsafe_index.md
+++ b/docs/api/threadsafe_index.md
@@ -1,6 +1,6 @@
 # ThreadSafeAnnIndex - Thread-safe Nearest Neighbor Index
 
-The `ThreadSafeAnnIndex` class provides a thread-safe wrapper around `AnnIndex` for concurrent access, now utilizing helper functions for acquiring locks to ensure consistent error handling. With the recent update, the serialization and deserialization processes now use `bincode` version 3.0.0, which may affect the API or behavior.
+The `ThreadSafeAnnIndex` class provides a thread-safe wrapper around `AnnIndex` for concurrent access, now utilizing helper functions for acquiring locks to ensure consistent error handling.
 
 ## Constructor
 
@@ -42,10 +42,10 @@ Thread-safe batch search. This method now includes enhanced error handling for r
 Thread-safe filtered search using a custom Python callback function and a helper function to acquire a read lock.
 
 ### `save(path: str)`
-Thread-safe save using a helper function to acquire a read lock. The serialization process now uses `bincode` version 3.0.0, which may affect compatibility with previous versions.
+Thread-safe save using a helper function to acquire a read lock.
 
 ### `static load(path: str) -> ThreadSafeAnnIndex`
-Thread-safe load. The deserialization process now uses `bincode` version 3.0.0, which may affect compatibility with previous versions.
+Thread-safe load.
 
 ## Example
 ```python


### PR DESCRIPTION
Reverts Programmers-Paradise/Annie#240

---
## EntelligenceAI PR Summary 
 Documentation cleanup removing outdated `bincode` 3.0.0 upgrade references and compatibility warnings.
- Removed bincode version references from HNSW index API documentation
- Removed bincode implementation details from threadsafe index class description
- Cleaned up `save()` and `load()` method documentation to remove serialization compatibility concerns
- Streamlined documentation to be more user-facing and less implementation-focused 

